### PR TITLE
Consistency and Bug Fixes

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -21,5 +21,5 @@ minecraft {
 }
 
 dependencies {
-    implementation 'org.spongepowered:mixin:0.8.4'
+     compileOnly group:'org.spongepowered', name:'mixin', version:'0.8.4'
 }

--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -19,3 +19,7 @@ minecraft {
         }
     }
 }
+
+dependencies {
+    implementation 'org.spongepowered:mixin:0.8.4'
+}

--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -5,10 +5,6 @@ plugins {
 
 archivesBaseName = "${mod_name}-common-${minecraft_version}"
 
-repositories {
-    mavenCentral()
-}
-
 minecraft {
     version(minecraft_version)
     runs {   

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -40,6 +40,8 @@ processResources {
     }
 }
 
+sourceSets.main.resources.srcDir '../Common/src/main/resources'
+
 tasks.withType(JavaCompile) {
     source(project(":Common").sourceSets.main.allSource)
 }

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -40,12 +40,6 @@ processResources {
     }
 }
 
-tasks.withType(JavaCompile).configureEach {
-    it.options.encoding = "UTF-8"
-
-    it.options.release = 16
-}
-
 tasks.withType(JavaCompile) {
     source(project(":Common").sourceSets.main.allSource)
 }

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -6,9 +6,6 @@ plugins {
 
 archivesBaseName = "${mod_name}-fabric-${minecraft_version}"
 
-repositories {
-}
-
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
     mappings loom.officialMojangMappings()

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -66,9 +66,6 @@ minecraft {
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
-repositories {
-}
-
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compileOnly project(":Common")

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -64,7 +64,8 @@ minecraft {
     }
 }
 
-sourceSets.main.resources { srcDir 'src/generated/resources' }
+sourceSets.main.resources.srcDir 'src/generated/resources'
+sourceSets.main.resources.srcDir '../Common/src/main/resources'
 
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -22,4 +22,19 @@ subprojects {
             ])
         }
     }
+    
+    repositories {
+
+        mavenCentral()
+
+        maven {
+            name = 'Sponge / Mixin'
+            url = 'https://repo.spongepowered.org/repository/maven-public/'
+        }
+
+        maven {
+            name = 'BlameJared Maven (CrT / Bookshelf)'
+            url = 'https://maven.blamejared.com'
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,4 +37,11 @@ subprojects {
             url = 'https://maven.blamejared.com'
         }
     }
+    
+
+    tasks.withType(JavaCompile).configureEach {
+    
+        it.options.encoding = 'UTF-8'
+        it.options.release = 16
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ common_server_run_name=Common Server
 
 
 # Forge
-forge_version=37.0.82
+forge_version=37.0.85
 //forge_ats_enabled=true
 
 # Fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,8 @@ forge_version=37.0.85
 //forge_ats_enabled=true
 
 # Fabric
-fabric_version=0.40.1+1.17
-fabric_loader_version=0.11.7
+fabric_version=0.40.8+1.17
+fabric_loader_version=0.12.1
 
 # Mod options
 mod_name=MultiLoader


### PR DESCRIPTION
This PR aims to update a few things while also resolving bugs, quirky behavior, and inconsistencies.

- https://github.com/jaredlll08/MultiLoader-Template/commit/07b5f427402ddd7d5165fbc6efccd71ad6f1b1c7 - Common and Forge had their repositories dictated by the Fabric project. This was likely caused by all sub-projects sharing the same repository set. This was resolved by unifying the repositories block and moving them to the root project build script. I also added your maven here which may be controversial. My reasoning was that this would make things easier for both of us in the future. Your maven is also going to be the only source of Common compatible mods which need further testing and examples in the MDK.
- https://github.com/jaredlll08/MultiLoader-Template/commit/8550e017a18b0ee054eebd3e8861c23718247c9b - This was previously only applied to Fabric projects as the official Forge MDK has not accounted for this yet. I've moved these options to the root build script to apply them consistently. 
- https://github.com/jaredlll08/MultiLoader-Template/commit/2ddb1a3228284a9662ecfb0a21539eee80f88d19 - This only brings the Mixin classes such as annotations into the Common compilation classpath. It does not add Mixin to the Common runtime or allow Common to define new Mixin configs however this may be a good future addition.
- https://github.com/jaredlll08/MultiLoader-Template/commit/52f493e141bf52275fdd73a78d70d8285bbd600a This resolves the issue where resources were not included with the Forge or Fabric compiled binaries. This fix is applied the same way Forge includes data generator resources. 