### PR TITLE
Add the refmap line to the Fabric mixins.json.

### DIFF
--- a/Fabric/src/main/resources/modid.mixins.json
+++ b/Fabric/src/main/resources/modid.mixins.json
@@ -3,6 +3,7 @@
     "minVersion": "0.8",
     "package": "com.example.examplemod.mixin",
     "compatibilityLevel": "JAVA_17",
+    "refmap": "modid.refmap.json",
     "mixins": [
     ],
     "client": [


### PR DESCRIPTION
This does not include an expansion to change it dynamically, but this is just so that no one misses it in the 1.19 branch.