### PR TITLE
Cleanup and improve expansions in metadata files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,27 @@ subprojects {
     }
 
     processResources {
-        filesMatching(['pack.mcmeta', 'fabric.mod.json', 'mods.toml', '*.mixins.json']) {
-            expand project.properties
+        def expandProps = [
+                "version": version,
+                "group": project.group, //Else we target the task's group.
+                "minecraft_version": minecraft_version,
+                "forge_version": forge_version,
+                "forge_loader_version_range": forge_loader_version_range,
+                "forge_version_range": forge_version_range,
+                "minecraft_version_range": minecraft_version_range,
+                "fabric_version": fabric_version,
+                "fabric_loader_version": fabric_loader_version,
+                "mod_name": mod_name,
+                "mod_author": mod_author,
+                "mod_id": mod_id,
+                "license": license,
+                "description": project.description
+        ]
+
+        filesMatching(['pack.mcmeta', 'fabric.mod.json', 'META-INF/mods.toml', '*.mixins.json']) {
+            expand expandProps
         }
+        inputs.properties(expandProps)
     }
 
     // Disables Gradle's custom module metadata from being published to maven. The

--- a/common/src/main/java/com/example/examplemod/Constants.java
+++ b/common/src/main/java/com/example/examplemod/Constants.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 
 public class Constants {
 
-	public static final String MOD_ID = "multiloader";
-	public static final String MOD_NAME = "Multi Loader Template";
+	public static final String MOD_ID = "examplemod";
+	public static final String MOD_NAME = "ExampleMod";
 	public static final Logger LOG = LoggerFactory.getLogger(MOD_NAME);
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
     "id": "mod_id",
     "version": "${version}",
     "name": "${mod_name}",
-    "description": "This is an example description! Tell everyone what your mod is about!",
+    "description": "${description}",
     "authors": [
         "${mod_author}"
     ],
@@ -11,8 +11,8 @@
         "homepage": "https://fabricmc.net/",
         "sources": "https://github.com/FabricMC/fabric-example-mod"
     },
-    "license": "CC0-1.0",
-    "icon": "assets/modid/icon.png",
+    "license": "${license}",
+    "icon": "assets/modid/${mod_id}.png",
     "environment": "*",
     "entrypoints": {
         "main": [
@@ -20,8 +20,8 @@
         ]
     },
     "mixins": [
-        "examplemod.mixins.json",
-        "examplemod.fabric.mixins.json"
+        "${mod_id}.mixins.json",
+        "${mod_id}.fabric.mixins.json"
     ],
     "depends": {
         "fabricloader": ">=0.14",

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -17,6 +17,8 @@ mixin {
 minecraft {
     mappings channel: 'official', version: minecraft_version
 
+    copyIdeResources = true //Calls processResources when in dev
+
     // Automatically enable forge AccessTransformers if the file exists
     // This location is hardcoded in Forge and can not be changed.
     // https://github.com/MinecraftForge/MinecraftForge/blob/be1698bb1554f9c8fa2f58e32b9ab70bc4385e60/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java#L123

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,28 +1,26 @@
 modLoader = "javafml" #mandatory
-loaderVersion = "[46,)" #mandatory This is typically bumped every Minecraft version by Forge. See https://files.minecraftforge.net/ for a list of versions.
-license = "C0-1.0" # Review your options at https://choosealicense.com/.
+loaderVersion = "${forge_loader_version_range}" #mandatory This is typically bumped every Minecraft version by Forge. See https://files.minecraftforge.net/ for a list of versions.
+license = "${license}" # Review your options at https://choosealicense.com/.
 #issueTrackerURL="https://change.me.to.your.issue.tracker.example.invalid/" #optional
 [[mods]] #mandatory
-modId = "multiloader" #mandatory
-version = "${file.jarVersion}" #mandatory
+modId = "${mod_id}" #mandatory
+version = "${version}" #mandatory
 displayName = "${mod_name}" #mandatory
 #updateJSONURL="https://change.me.example.invalid/updates.json" #optional (see https://mcforge.readthedocs.io/en/latest/gettingstarted/autoupdate/)
 #displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional (displayed in the mod UI)
-logoFile = "multiloader.png" #optional (needs to be in the root of your mod jar (root of your 'resources' folder))
+logoFile = "${mod_id}.png" #optional (needs to be in the root of your mod jar (root of your 'resources' folder))
 credits = "Thanks for this example mod goes to Java" #optional
 authors = "${mod_author}" #optional
-description = '''
-This is a long form description of the mod. You can write whatever you want here
-''' #mandatory (Supports multiline text)
-[[dependencies.multiloader]] #optional
+description = '''${description}''' #mandatory (Supports multiline text)
+[[dependencies.${mod_id}]] #optional
 modId = "forge" #mandatory
 mandatory = true #mandatory
-versionRange = "[46,)" #mandatory
+versionRange = "${forge_version_range}" #mandatory
 ordering = "NONE" # The order that this dependency should load in relation to your mod, required to be either 'BEFORE' or 'AFTER' if the dependency is not mandatory
 side = "BOTH" # Side this dependency is applied on - 'BOTH', 'CLIENT' or 'SERVER'
-[[dependencies.multiloader]]
+[[dependencies.${mod_id}]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.20,1.21)"
+versionRange = "${minecraft_version_range}"
 ordering = "NONE"
 side = "BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+# Important Notes:
+# fabric.mod.json's modid field cannot be expanded, you must change it manually.
+# Every field you add must be added to the root build.gradle expandProps map.
+
 # Project
 version=1.0.0
 group=com.example.examplemod
@@ -7,6 +11,9 @@ minecraft_version=1.20
 
 # Forge
 forge_version=46.0.12
+forge_loader_version_range=[46,)
+forge_version_range=[46,)
+minecraft_version_range=[1.20, 1.21)
 
 # Fabric
 fabric_version=0.83.0+1.20
@@ -16,6 +23,8 @@ fabric_loader_version=0.14.21
 mod_name=ExampleMod
 mod_author=Jared
 mod_id=examplemod
+license=C0-1.0
+description=The description of your mod. \nAccepts multilines.
 
 # Gradle
 org.gradle.jvmargs=-Xmx3G


### PR DESCRIPTION
This pull request aims to improve the processResources aspect of the template.

- Forge project now properly expands files.
- Forge project now will call processResources before running in the IDE.
- The expanded properties are now stored in a map in the root `build.gradle`
- Some more fields, such as license or description were added to the `gradle.properties` file.
- A warning and explanation was added to the `gradle.properties``` file.
- The name of the mod in code was changed to `examplemod` to fit accordingly with what it is in Gradle properties.