### PR TITLE
Replace examplemod with ${mod_id} in mod files.

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
         "sources": "https://github.com/FabricMC/fabric-example-mod"
     },
     "license": "${license}",
-    "icon": "assets/modid/${mod_id}.png",
+    "icon": "assets/${mod_id}/${mod_id}.png",
     "environment": "*",
     "entrypoints": {
         "main": [

--- a/neoforge/src/main/resources/META-INF/mods.toml
+++ b/neoforge/src/main/resources/META-INF/mods.toml
@@ -13,16 +13,16 @@ credits="${credits}" #optional
 authors = "${mod_author}" #optional
 description = '''${description}''' #mandatory (Supports multiline text)
 [[mixins]]
-config = "examplemod.mixins.json"
+config = "${mod_id}.mixins.json"
 [[mixins]]
-config = "examplemod.neoforge.mixins.json"
-[[dependencies.${ mod_id }]] #optional
+config = "${mod_id}.neoforge.mixins.json"
+[[dependencies.${mod_id}]] #optional
 modId = "neoforge" #mandatory
 mandatory = true #mandatory
 versionRange = "${neoforge_loader_version_range}" #mandatory
 ordering = "NONE" # The order that this dependency should load in relation to your mod, required to be either 'BEFORE' or 'AFTER' if the dependency is not mandatory
 side = "BOTH" # Side this dependency is applied on - 'BOTH', 'CLIENT' or 'SERVER'
-[[dependencies.${ mod_id }]]
+[[dependencies.${mod_id}]]
 modId = "minecraft"
 mandatory = true
 versionRange = "${minecraft_version_range}"


### PR DESCRIPTION
This PR replaces the examplemod in NeoForge mods.toml's mixin blocks, and Fabric's mod icon folder.

This also fixes NeoForge having spaces (${ mod_id }) )in the dependency block headers.