### PR TITLE
Update Fabric Mod ID in fabric.mod.json

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
     ],
     "depends": {
         "fabricloader": ">=0.14",
-        "fabric": "*",
+        "fabric-api": "*",
         "minecraft": "1.20.2",
         "java": ">=17"
     },


### PR DESCRIPTION
Ever since 1.19.2, Fabric API now has the `fabric-api` modid, with the `fabric` modid being deprecated. It is ideal to swap to it so error messages for not having Fabric API become more clear for users.