### PR TITLE
Remove outdated warning about expanding fabric.mod.json's mod_id

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 # Important Notes:
-# fabric.mod.json's modid field cannot be expanded, you must change it manually.
 # Every field you add must be added to the root build.gradle expandProps map.
 
 # Project


### PR DESCRIPTION
```
# fabric.mod.json's modid field cannot be expanded, you must change it manually.
```
This note in the `gradle.properties` file is outdated and should be removed now that you are expanding the mod_id in the fabric.mod.json:
https://github.com/jaredlll08/MultiLoader-Template/blob/1.20.2/fabric/src/main/resources/fabric.mod.json#L4