### PR TITLE
Replace `implementation` with `modCompileOnly` in the `fabric` subproject for consistency with the `forge` subproject

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
-    implementation project(":common")
+    modCompileOnly project(":common")
 }
 
 loom {


### PR DESCRIPTION
This was previously discussed in discord before, and Jared has approved the idea.