### PR TITLE
Fix multiline mod descriptions resulting in an invalid `fabric.mod.json`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ mod_author=Jared
 mod_id=examplemod
 license=CC0-1.0
 credits=
-description=The description of your mod. \nAccepts multilines.
+description=The description of your mod. \\nAccepts multilines (but they must be double-escaped).
 minecraft_version_range=[1.20.6, 1.21)
 
 # Fabric

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -11,7 +11,7 @@ displayName = "${mod_name}" #mandatory
 logoFile="${mod_id}.png" #optional
 credits="${credits}" #optional
 authors = "${mod_author}" #optional
-description = '''${description}''' #mandatory (Supports multiline text)
+description = "${description}" #mandatory (Supports multiline text)
 [[mixins]]
 config = "${mod_id}.mixins.json"
 [[mixins]]


### PR DESCRIPTION
Currently newline descriptions get put into `fabric.mod.json` as shown below, which is invalid json.
```json
{
	"schemaVersion": 1,
	"id": "...",
	"description": "The description of your mod. 
Accepts multilines.",
}
```
With this fix, they now look like this
```json
{
	"schemaVersion": 1,
	"id": "...",
	"description": "The description of your mod. \nAccepts multilines.",
}
```