### PR TITLE
fix-json-multiline

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -103,9 +103,18 @@ processResources {
             'java_version'                 : java_version
     ]
 
-    filesMatching(['pack.mcmeta', 'fabric.mod.json', 'META-INF/mods.toml', 'META-INF/neoforge.mods.toml', '*.mixins.json']) {
+    var jsonExpandProps = expandProps.collectEntries {
+        key, value -> [(key): value instanceof String ? value.replace("\n", "\\\\n") : value]
+    }
+
+    filesMatching(['META-INF/mods.toml', 'META-INF/neoforge.mods.toml']) {
         expand expandProps
     }
+
+    filesMatching(['pack.mcmeta', 'fabric.mod.json', '*.mixins.json']) {
+        expand jsonExpandProps
+    }
+
     inputs.properties(expandProps)
 }
 


### PR DESCRIPTION
With some help apparently this changes should fix the multiline error I mentioned on https://github.com/jaredlll08/MultiLoader-Template/issues/89

This results in a new line that looks like this:

```json
"description": "Remove Mouseover Highlight\\nby MrAmericanMike",
```

JSON validates. And apparently that how a new line in JSON should look like. https://stackoverflow.com/questions/4253367/how-to-escape-a-json-string-containing-newline-characters-using-javascript

PS: I also moved the pack.mcmeta to use that, as it's technically a json file too, even when it's not using multiline, but I guess it's better just to be safe. And this way if other edge cases need special handling, we should be ready.