### PR TITLE
Fix IDE-compat project compile deps on common with new attribute

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-loader.gradle
+++ b/buildSrc/src/main/groovy/multiloader-loader.gradle
@@ -16,6 +16,10 @@ dependencies {
         capabilities {
             requireCapability "$group:$mod_id"
         }
+        def loaderAttribute = Attribute.of('io.github.mcgradleconventions.loader', String)
+        attributes {
+            attribute(loaderAttribute, 'common')
+        }
     }
     commonJava project(path: ':common', configuration: 'commonJava')
     commonResources project(path: ':common', configuration: 'commonResources')


### PR DESCRIPTION
These got broken during https://github.com/jaredlll08/MultiLoader-Template/pull/108