### PR TITLE
Simpler Template Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ This project provides a Gradle project template that can compile Minecraft mods 
 ### IntelliJ IDEA
 This guide will show how to import the MultiLoader Template into IntelliJ IDEA. The setup process is roughly equivalent to setting up the modloaders independently and should be very familiar to anyone who has worked with their MDKs.
 
-1. Clone or download this repository to your computer.
-2. Configure the project by setting the properties in the `gradle.properties` file. You will also need to change the `rootProject.name`  property in `settings.gradle`, this should match the folder name of your project, or else IDEA may complain.
-3. Open the template's root folder as a new project in IDEA. This is the folder that contains this README.md file and the gradlew executable.
-4. If your default JVM/JDK is not Java 21 you will encounter an error when opening the project. This error is fixed by going to `File > Settings > Build, Execution, Deployment > Build Tools > Gradle > Gradle JVM` and changing the value to a valid Java 21 JVM. You will also need to set the Project SDK to Java 21. This can be done by going to `File > Project Structure > Project SDK`. Once both have been set open the Gradle tab in IDEA and click the refresh button to reload the project.
-5. Open your Run/Debug Configurations. Under the `Application` category there should now be options to run Fabric and NeoForge projects. Select one of the client options and try to run it.
-6. Assuming you were able to run the game in step 5 your workspace should now be set up.
+1. Download the template from [mctemplates.net](https://mctemplates.net/), by filling out your mods name, id and group.
+2. Open the template's root folder as a new project in IDEA. This is the folder that contains this README.md file and the gradlew executable.
+3. If your default JVM/JDK is not Java 21 you will encounter an error when opening the project. This error is fixed by going to `File > Settings > Build, Execution, Deployment > Build Tools > Gradle > Gradle JVM` and changing the value to a valid Java 21 JVM. You will also need to set the Project SDK to Java 21. This can be done by going to `File > Project Structure > Project SDK`. Once both have been set open the Gradle tab in IDEA and click the refresh button to reload the project.
+4. Open your Run/Debug Configurations. Under the `Application` category there should now be options to run Fabric and NeoForge projects. Select one of the client options and try to run it.
+5. Assuming you were able to run the game in step 5 your workspace should now be set up.
 
 ### Eclipse
 While it is possible to use this template in Eclipse it is not recommended. During the development of this template multiple critical bugs and quirks related to Eclipse were found at nearly every level of the required build tools. While we continue to work with these tools to report and resolve issues support for projects like these are not there yet. For now Eclipse is considered unsupported by this project. The development cycle for build tools is notoriously slow so there are no ETAs available.


### PR DESCRIPTION
This adds a direct link to a website of mine to the README, which simplifies the setup process by eleminating the renaming of dirs and classes, after cloning the repo.
The website is inspired by the [Fabrics Template Generator](https://fabricmc.net/develop/template/).
It's open source (https://github.com/1TheCrazy/McTemplates) and automatically uses every branch (version) of this repo and therefore automatically uses newest changes and only serves as a wrapper for renaming paths and classes so that they already contain your mods info (which I find annoying, so I made this website).

This is of course a pretty minor 3rd party (and therefore potentially risky) PR, so I see that this may not be even considered to merge.

Thank you for taking the time to read this👋 