### PR TITLE
bump parchment version to latest for 1.21.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@ minecraft_version_range=[1.21.11, 1.22)
 ## https://projects.neoforged.net/neoforged/neoform
 neo_form_version=1.21.11-20251209.172050
 # The version of ParchmentMC that is used, see https://parchmentmc.org/docs/getting-started#choose-a-version for new versions
-parchment_minecraft=1.21.10
-parchment_version=2025.10.12
+parchment_minecraft=1.21.11
+parchment_version=2025.12.20
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
 fabric_version=0.139.5+1.21.11


### PR DESCRIPTION
values taken from https://parchmentmc.org/docs/getting-started#choose-a-version