### PR TITLE
Don't set artifactId manually for publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,3 +4,6 @@ plugins {
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.141' apply false
 }
+
+group = property("group")
+version = property("version")

--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -3,10 +3,6 @@ plugins {
     id 'maven-publish'
 }
 
-base {
-    archivesName = "${mod_id}-${project.name}-${minecraft_version}"
-}
-
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(java_version)
     withSourcesJar()
@@ -92,7 +88,6 @@ processResources {
 publishing {
     publications {
         register('mavenJava', MavenPublication) {
-            artifactId base.archivesName.get()
             from components.java
         }
     }

--- a/buildSrc/src/main/groovy/multiloader-loader.gradle
+++ b/buildSrc/src/main/groovy/multiloader-loader.gradle
@@ -2,24 +2,26 @@ plugins {
     id 'multiloader-common'
 }
 
+String commonPath = ":$mod_id-common"
+
 configurations {
-    commonJava{
+    commonJava {
         canBeResolved = true
     }
-    commonResources{
+    commonResources {
         canBeResolved = true
     }
 }
 
 dependencies {
-    compileOnly(project(':common')) {
+    compileOnly(project(commonPath)) {
         def loaderAttribute = Attribute.of('io.github.mcgradleconventions.loader', String)
         attributes {
             attribute(loaderAttribute, 'common')
         }
     }
-    commonJava project(path: ':common', configuration: 'commonJava')
-    commonResources project(path: ':common', configuration: 'commonResources')
+    commonJava project(path: commonPath, configuration: 'commonJava')
+    commonResources project(path: commonPath, configuration: 'commonResources')
 }
 
 tasks.named('compileJava', JavaCompile) {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'multiloader-loader'
     id 'net.fabricmc.fabric-loom'
 }
+
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
     implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
@@ -9,7 +10,7 @@ dependencies {
 }
 
 loom {
-    def aw = project(':common').file("src/main/resources/${mod_id}.accesswidener")
+    def aw = project(":$mod_id-common").file("src/main/resources/${mod_id}.accesswidener")
     if (aw.exists()) {
         accessWidenerPath.set(aw)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 # Project
 version=26.1.2.0
-group=com.example.examplemod
+group=com.example
 java_version=25
 
 # Common

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -6,7 +6,7 @@ plugins {
 neoForge {
     version = neoforge_version
     // Automatically enable neoforge AccessTransformers if the file exists
-    def at = project(':common').file('src/main/resources/META-INF/accesstransformer.cfg')
+    def at = project(":$mod_id-common").file('src/main/resources/META-INF/accesstransformer.cfg')
     if (at.exists()) {
         accessTransformers.from(at.absolutePath)
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,8 +20,18 @@ plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
-// This should match the folder name of the project, or else IDEA may complain (see https://youtrack.jetbrains.com/issue/IDEA-317606)
-rootProject.name = 'MultiLoader-Template'
-include('common')
-include('fabric')
-include('neoforge')
+String modId = providers.gradleProperty("mod_id").get()
+
+rootProject.name = modId
+
+rootDir.listFiles().findAll {
+    it.isDirectory()
+        && it.name != "buildSrc"
+        && (new File(it, "build.gradle").exists() || new File(it, "build.gradle.kts").exists())
+}.forEach {
+    String relativePath = rootDir.toPath().relativize(it.toPath()).toString()
+    String projectName = ":$modId-$relativePath"
+
+    include(projectName)
+    project(projectName).projectDir = it
+}


### PR DESCRIPTION
Setting artifactId manually is bad practice, the name of the projects should be changed instead.

Reference: https://lukebemish.dev/2026/02/22/gradle-shorts-1-publication-coordinates.html