### PR TITLE
Make mod name more readable in loaders and pack file

### DIFF
--- a/build-logic/src/main/groovy/multiloader-common.gradle
+++ b/build-logic/src/main/groovy/multiloader-common.gradle
@@ -43,6 +43,7 @@ processResources {
             'fabric_version'               : fabric_version,
             'fabric_loader_version'        : fabric_loader_version,
             'mod_name'                     : mod_name,
+            'mod_display_name'             : mod_display_name,
             'mod_author'                   : mod_author,
             'mod_id'                       : mod_id,
             'license'                      : license,

--- a/common/src/main/java/com/example/examplemod/Constants.java
+++ b/common/src/main/java/com/example/examplemod/Constants.java
@@ -7,5 +7,6 @@ public class Constants {
 
     public static final String MOD_ID = "examplemod";
     public static final String MOD_NAME = "ExampleMod";
+    public static final String MOD_DISPLAY_NAME = "Example Mod";
     public static final Logger LOG = LoggerFactory.getLogger(MOD_NAME);
 }

--- a/common/src/main/java/com/example/examplemod/mixin/MixinMinecraft.java
+++ b/common/src/main/java/com/example/examplemod/mixin/MixinMinecraft.java
@@ -14,7 +14,7 @@ public class MixinMinecraft {
     @Inject(at = @At("TAIL"), method = "<init>")
     private void init(CallbackInfo info) {
 
-        Constants.LOG.info("This line is printed by an example mod common mixin!");
+        Constants.LOG.info("This line is printed by an {} common mixin!", Constants.MOD_DISPLAY_NAME);
         Constants.LOG.info("MC Version: {}", SharedConstants.getCurrentVersion().name());
     }
 }

--- a/common/src/main/resources/pack.mcmeta
+++ b/common/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "description": "${mod_name}",
+        "description": "${mod_display_name}",
         "pack_format": 8
     }
 }

--- a/fabric/src/main/java/com/example/examplemod/mixin/MixinTitleScreen.java
+++ b/fabric/src/main/java/com/example/examplemod/mixin/MixinTitleScreen.java
@@ -14,7 +14,7 @@ public class MixinTitleScreen {
     @Inject(at = @At("HEAD"), method = "init()V")
     private void init(CallbackInfo info) {
 
-        Constants.LOG.info("This line is printed by an example mod mixin from Fabric!");
+        Constants.LOG.info("This line is printed by an {} mixin from Fabric!", Constants.MOD_DISPLAY_NAME);
         Constants.LOG.info("MC Version: {}", SharedConstants.getCurrentVersion().name());
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -2,7 +2,7 @@
     "schemaVersion": 1,
     "id": "${mod_id}",
     "version": "${version}",
-    "name": "${mod_name}",
+    "name": "${mod_display_name}",
     "description": "${description}",
     "authors": [
         "${mod_author}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ java_version=25
 # Common
 minecraft_version=26.2
 mod_name=ExampleMod
+mod_display_name=Example Mod
 mod_author=Jared
 mod_id=examplemod
 license=CC0-1.0

--- a/neoforge/src/main/java/com/example/examplemod/mixin/MixinTitleScreen.java
+++ b/neoforge/src/main/java/com/example/examplemod/mixin/MixinTitleScreen.java
@@ -14,7 +14,7 @@ public class MixinTitleScreen {
     @Inject(at = @At("HEAD"), method = "init()V")
     private void init(CallbackInfo info) {
 
-        Constants.LOG.info("This line is printed by an example mod mixin from NeoForge!");
+        Constants.LOG.info("This line is printed by an {} mixin from NeoForge!", Constants.MOD_DISPLAY_NAME);
         Constants.LOG.info("MC Version: {}", SharedConstants.getCurrentVersion().name());
     }
 }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -5,7 +5,7 @@ license = "${license}" # Review your options at https://choosealicense.com/.
 [[mods]] #mandatory
 modId = "${mod_id}" #mandatory
 version = "${version}" #mandatory
-displayName = "${mod_name}" #mandatory
+displayName = "${mod_display_name}" #mandatory
 #updateJSONURL="https://change.me.example.invalid/updates.json" #optional (see https://docs.neoforged.net/docs/misc/updatechecker/)
 #displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional (displayed in the mod UI)
 logoFile="${mod_id}.png" #optional


### PR DESCRIPTION
Currently, the `mod_name` property is the mod's name without spaces, 'ExampleMod', and is passed to `displayName` in `neoforge.mods.toml`, `name` in `fabric.mod.json`, and `description` in `pack.mcmeta`. The documentation and example code for all three indicate that it should be the more user-facing 'Example Mod':
1. NeoForge docs describe the [`mod_name`](https://docs.neoforged.net/docs/gettingstarted/modfiles) gradle property as "The human-readable display name of your mod," and says it's usually only used in the mod list. This is true of all versions of the docs (1.20.3-26.1). The ModDevGradle example mod sets its value to ["Example Mod"](https://github.com/NeoForgeMDKs/MDK-26.2-ModDevGradle/blob/main/gradle.properties#L25), and only passes it to [displayName](https://github.com/NeoForgeMDKs/MDK-26.2-ModDevGradle/blob/main/src/main/templates/META-INF/neoforge.mods.toml#L24) in the mods.toml.
2. Fabric docs describe the [name](https://wiki.fabricmc.net/documentation:fabric_mod_json_spec#optional_fields_metadata) field as a "user-facing mod name," and the example mod also sets it's value to ["Example Mod"](https://github.com/FabricMC/fabric-example-mod/blob/26.1.2/src/main/resources/fabric.mod.json#L5) in the mod.json. This is also true of all versions of the example mod (1.20-26.1.2).
3. The MC wiki shows [examples](https://minecraft.wiki/w/Pack_format) of the `description` field in the `pack.mcmeta` such as "Example datapack for Minecraft 1.21," and the Minecraft codebase contains examples like "New features and content for Minecraft 1.20."

This PR adds the property `mod_display_name` to `gradle.properties` and uses it as the loader's name fields and as the `pack.mcmeta` description, rather than `mod_name`. It also adds `MOD_DISPLAY_NAME` to `Constants` with the same value, and uses that for the example mixin info logging, rather than "example mod".

This PR doesn't change the use of `mod_name` for the license file renaming or the `Specification-Title` key in the injected manifest file. While the example given in Oracle docs of ["Java Utility Classes"](https://docs.oracle.com/javase/1.5.0/docs/guide/versioning/spec/versioning2.html#wp91706) for `Specification-Title` does indicate that 'Example Mod' would be more appropriate there too, it doesn't seem to be as user-facing, so I didn't change it. If it is, or if it's value is ever checked against the display name or pack description, then that should probably change too.